### PR TITLE
add search field functionality / fix filter reset on new todo / adapt sorting

### DIFF
--- a/src/main/java/de/doubleslash/keeptask/model/Model.java
+++ b/src/main/java/de/doubleslash/keeptask/model/Model.java
@@ -50,8 +50,7 @@ public class Model {
   }
 
   public void setWorkItems(List<WorkItem> workItems) {
-    this.workItems.clear();
-    this.workItems.addAll(workItems);
+    this.workItems.setAll(workItems);
   }
 
   public ObservableList<WorkItem> getWorkItems() {

--- a/src/main/java/de/doubleslash/keeptask/view/FilterController.java
+++ b/src/main/java/de/doubleslash/keeptask/view/FilterController.java
@@ -119,10 +119,9 @@ public class FilterController {
   private void updateProjectFilterButtons() {
     Set<String> projectNames = model.getWorkItems().stream().map(workItem -> workItem.getProject())
         .collect(Collectors.toSet());
-    projectFilterHbox.getChildren().clear();
 
     // recreate buttons
-    projectFilterHbox.getChildren().addAll(projectNames.stream().map(projectName -> {
+    projectFilterHbox.getChildren().setAll(projectNames.stream().map(projectName -> {
               ToggleButton button = new ToggleButton(projectName);
               button.setUserData(projectName);
               button.setSelected(projectNameFilters.contains(projectName));

--- a/src/main/java/de/doubleslash/keeptask/view/FilterController.java
+++ b/src/main/java/de/doubleslash/keeptask/view/FilterController.java
@@ -35,6 +35,7 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.HBox;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -80,6 +81,10 @@ public class FilterController {
     updateProjectFilterButtons();
 
     alsoCompletedCheckbox.setOnAction(actionEvent -> updateFilters());
+
+    searchTextInput.textProperty().addListener((observable, oldValue, newValue) -> {
+      updateFilters();
+    });
 
     todayToggleButton.setUserData(
         (Predicate<WorkItem>) workItem -> workItem.getDueDateTime() == null ? false
@@ -161,7 +166,9 @@ public class FilterController {
           : projectNameFilters.stream().anyMatch(filter -> workItem.getProject().equals(filter));
       boolean completedMatches = alsoCompletedCheckbox.isSelected() ? true : !workItem.isFinished();
 
-      return timeFilterMatches && projectNameMatches && completedMatches;
+      boolean searchQueryMatches = StringUtils.containsIgnoreCase(workItem.getTodo(), searchTextInput.getText());
+
+      return timeFilterMatches && projectNameMatches && completedMatches && searchQueryMatches;
     };
     return filterPredicate;
   }

--- a/src/main/java/de/doubleslash/keeptask/view/MainWindowController.java
+++ b/src/main/java/de/doubleslash/keeptask/view/MainWindowController.java
@@ -125,8 +125,7 @@ public class MainWindowController {
     sortedWorkItems = new SortedList<>(model.getWorkFilteredItems());
     Comparator<WorkItem> comparing = Comparator.comparing(
         workItem -> workItem.getDueDateTime() != null ? workItem.getDueDateTime()
-            : LocalDateTime.MIN);
-    comparing = comparing.reversed();
+            : LocalDateTime.MAX);
     sortedWorkItems.setComparator(comparing);
 
     loadFiltersLayout();

--- a/src/main/java/de/doubleslash/keeptask/view/MainWindowController.java
+++ b/src/main/java/de/doubleslash/keeptask/view/MainWindowController.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.SortedList;
@@ -191,12 +192,10 @@ public class MainWindowController {
 
   private void refreshTodos() {
     ObservableList<Node> children = workItemVBox.getChildren();
-    children.clear();
 
-    for (WorkItem workItem : sortedWorkItems) {
-      Node todoNode = createTodoNode(workItem);
-      children.add(todoNode);
-    }
+    List<Node> todosAsNodes = sortedWorkItems.stream().map(this::createTodoNode).collect(
+        Collectors.toList());
+    children.setAll(todosAsNodes);
 
     if (mainStage != null) {
       mainStage.sizeToScene();


### PR DESCRIPTION
* Search is performed on "todo" field only. Search is not case sensitive.
* using "setAll" instead of "clear"+"addAll" now to prevent loss of configured filter
* work items are now sorted with nearest due date at the top